### PR TITLE
Downgrade `thiserror` to `1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 [dependencies]
 steamworks-sys = { path = "./steamworks-sys", version = "0.11.0" }
 libloading = { version = "0.8", default-features = false } 
-thiserror = "2.0"
+thiserror = "1"
 bitflags = "2.8"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
Needed by internal projects.