### PR TITLE
Enable user_stats module for achievements and leaderboards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use sys::{ESteamAPIInitResult, SteamErrMsg};
 
 use core::ffi::c_void;
 use std::collections::HashMap;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
@@ -33,7 +33,7 @@ pub use crate::error::*;
 // pub use crate::timeline::*;
 // pub use crate::ugc::*;
 // pub use crate::user::*;
-// pub use crate::user_stats::*;
+pub use crate::user_stats::*;
 // pub use crate::utils::*;
 
 mod app;
@@ -56,7 +56,7 @@ mod error;
 // pub mod timeline;
 // mod ugc;
 // mod user;
-// mod user_stats;
+mod user_stats;
 // mod utils;
 
 pub type SResult<T> = Result<T, SteamError>;
@@ -344,6 +344,18 @@ where
             debug_assert!(!apps.is_null());
             Apps {
                 apps: apps,
+                inner: self.inner.clone(),
+            }
+        }
+    }
+
+    /// Returns an accessor to the steam user stats interface
+    pub fn user_stats(&self) -> UserStats<Manager> {
+        unsafe {
+            let us = self.inner.lib.SteamAPI_SteamUserStats_v013();
+            debug_assert!(!us.is_null());
+            UserStats {
+                user_stats: us,
                 inner: self.inner.clone(),
             }
         }

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -21,7 +21,7 @@ impl<Manager> UserStats<Manager> {
     {
         unsafe {
             let name = CString::new(name).unwrap();
-            let api_call = sys::SteamAPI_ISteamUserStats_FindLeaderboard(
+            let api_call = self.inner.lib.SteamAPI_ISteamUserStats_FindLeaderboard(
                 self.user_stats,
                 name.as_ptr() as *const _,
             );
@@ -78,12 +78,15 @@ impl<Manager> UserStats<Manager> {
                 }
             };
 
-            let api_call = sys::SteamAPI_ISteamUserStats_FindOrCreateLeaderboard(
-                self.user_stats,
-                name.as_ptr() as *const _,
-                sort_method,
-                display_type,
-            );
+            let api_call = self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_FindOrCreateLeaderboard(
+                    self.user_stats,
+                    name.as_ptr() as *const _,
+                    sort_method,
+                    display_type,
+                );
             register_call_result::<sys::LeaderboardFindResult_t, _, _>(
                 &self.inner,
                 api_call,
@@ -122,14 +125,17 @@ impl<Manager> UserStats<Manager> {
                     sys::ELeaderboardUploadScoreMethod::k_ELeaderboardUploadScoreMethodForceUpdate
                 }
             };
-            let api_call = sys::SteamAPI_ISteamUserStats_UploadLeaderboardScore(
-                self.user_stats,
-                leaderboard.0,
-                method,
-                score,
-                details.as_ptr(),
-                details.len() as _,
-            );
+            let api_call = self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_UploadLeaderboardScore(
+                    self.user_stats,
+                    leaderboard.0,
+                    method,
+                    score,
+                    details.as_ptr(),
+                    details.len() as _,
+                );
             register_call_result::<sys::LeaderboardScoreUploaded_t, _, _>(
                 &self.inner,
                 api_call,
@@ -177,14 +183,18 @@ impl<Manager> UserStats<Manager> {
                     sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestFriends
                 }
             };
-            let api_call = sys::SteamAPI_ISteamUserStats_DownloadLeaderboardEntries(
-                self.user_stats,
-                leaderboard.0,
-                request,
-                start as _,
-                end as _,
-            );
+            let api_call = self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_DownloadLeaderboardEntries(
+                    self.user_stats,
+                    leaderboard.0,
+                    request,
+                    start as _,
+                    end as _,
+                );
             let user_stats = self.user_stats as isize;
+            let lib = self.inner.lib.clone();
             register_call_result::<sys::LeaderboardScoresDownloaded_t, _, _>(
                 &self.inner,
                 api_call,
@@ -199,7 +209,7 @@ impl<Manager> UserStats<Manager> {
                             let mut entry: sys::LeaderboardEntry_t = std::mem::zeroed();
                             let mut details = Vec::with_capacity(max_details_len);
 
-                            sys::SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry(
+                            lib.SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry(
                                 user_stats as *mut _,
                                 v.m_hSteamLeaderboardEntries,
                                 idx,
@@ -229,10 +239,11 @@ impl<Manager> UserStats<Manager> {
         leaderboard: &Leaderboard,
     ) -> Option<LeaderboardDisplayType> {
         unsafe {
-            match sys::SteamAPI_ISteamUserStats_GetLeaderboardDisplayType(
-                self.user_stats,
-                leaderboard.0,
-            ) {
+            match self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetLeaderboardDisplayType(self.user_stats, leaderboard.0)
+            {
                 sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeNumeric => {
                     Some(LeaderboardDisplayType::Numeric)
                 }
@@ -253,10 +264,11 @@ impl<Manager> UserStats<Manager> {
         leaderboard: &Leaderboard,
     ) -> Option<LeaderboardSortMethod> {
         unsafe {
-            match sys::SteamAPI_ISteamUserStats_GetLeaderboardSortMethod(
-                self.user_stats,
-                leaderboard.0,
-            ) {
+            match self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetLeaderboardSortMethod(self.user_stats, leaderboard.0)
+            {
                 sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodAscending => {
                     Some(LeaderboardSortMethod::Ascending)
                 }
@@ -271,10 +283,11 @@ impl<Manager> UserStats<Manager> {
     /// Returns the name of a leaderboard handle. Returns an empty string if the leaderboard handle is invalid.
     pub fn get_leaderboard_name(&self, leaderboard: &Leaderboard) -> String {
         unsafe {
-            let name = CStr::from_ptr(sys::SteamAPI_ISteamUserStats_GetLeaderboardName(
-                self.user_stats,
-                leaderboard.0,
-            ));
+            let name = CStr::from_ptr(
+                self.inner
+                    .lib
+                    .SteamAPI_ISteamUserStats_GetLeaderboardName(self.user_stats, leaderboard.0),
+            );
             name.to_string_lossy().into()
         }
     }
@@ -282,14 +295,18 @@ impl<Manager> UserStats<Manager> {
     /// Returns the total number of entries in a leaderboard. Returns 0 if the leaderboard handle is invalid.
     pub fn get_leaderboard_entry_count(&self, leaderboard: &Leaderboard) -> i32 {
         unsafe {
-            sys::SteamAPI_ISteamUserStats_GetLeaderboardEntryCount(self.user_stats, leaderboard.0)
+            self.inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetLeaderboardEntryCount(self.user_stats, leaderboard.0)
         }
     }
 
     /// Triggers a [`UserStatsReceived`](./struct.UserStatsReceived.html) callback.
     pub fn request_user_stats(&self, steam_user_id: u64) {
         unsafe {
-            sys::SteamAPI_ISteamUserStats_RequestUserStats(self.user_stats, steam_user_id);
+            self.inner
+                .lib
+                .SteamAPI_ISteamUserStats_RequestUserStats(self.user_stats, steam_user_id);
         }
     }
 
@@ -307,8 +324,10 @@ impl<Manager> UserStats<Manager> {
         F: FnOnce(Result<GameId, SteamError>) + 'static + Send,
     {
         unsafe {
-            let api_call =
-                sys::SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages(self.user_stats);
+            let api_call = self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages(self.user_stats);
             register_call_result::<sys::GlobalAchievementPercentagesReady_t, _, _>(
                 &self.inner,
                 api_call,
@@ -335,7 +354,11 @@ impl<Manager> UserStats<Manager> {
     /// Requires [`request_current_stats()`](#method.request_current_stats) to have been called
     /// and a successful [`UserStatsReceived`](./struct.UserStatsReceived.html) callback processed.
     pub fn store_stats(&self) -> Result<(), ()> {
-        let success = unsafe { sys::SteamAPI_ISteamUserStats_StoreStats(self.user_stats) };
+        let success = unsafe {
+            self.inner
+                .lib
+                .SteamAPI_ISteamUserStats_StoreStats(self.user_stats)
+        };
         if success {
             Ok(())
         } else {
@@ -346,7 +369,9 @@ impl<Manager> UserStats<Manager> {
     /// Resets the current users stats and, optionally achievements.
     pub fn reset_all_stats(&self, achievements_too: bool) -> Result<(), ()> {
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_ResetAllStats(self.user_stats, achievements_too)
+            self.inner
+                .lib
+                .SteamAPI_ISteamUserStats_ResetAllStats(self.user_stats, achievements_too)
         };
         if success {
             Ok(())
@@ -366,7 +391,7 @@ impl<Manager> UserStats<Manager> {
 
         let mut value: i32 = 0;
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_GetStatInt32(
+            self.inner.lib.SteamAPI_ISteamUserStats_GetStatInt32(
                 self.user_stats,
                 name.as_ptr() as *const _,
                 &mut value,
@@ -392,7 +417,7 @@ impl<Manager> UserStats<Manager> {
         let name = CString::new(name).unwrap();
 
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetStatInt32(
+            self.inner.lib.SteamAPI_ISteamUserStats_SetStatInt32(
                 self.user_stats,
                 name.as_ptr() as *const _,
                 stat,
@@ -416,7 +441,7 @@ impl<Manager> UserStats<Manager> {
 
         let mut value: f32 = 0.0;
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_GetStatFloat(
+            self.inner.lib.SteamAPI_ISteamUserStats_GetStatFloat(
                 self.user_stats,
                 name.as_ptr() as *const _,
                 &mut value,
@@ -442,7 +467,7 @@ impl<Manager> UserStats<Manager> {
         let name = CString::new(name).unwrap();
 
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetStatFloat(
+            self.inner.lib.SteamAPI_ISteamUserStats_SetStatFloat(
                 self.user_stats,
                 name.as_ptr() as *const _,
                 stat,
@@ -477,7 +502,10 @@ impl<Manager> UserStats<Manager> {
     /// *Note: Returns an error for AppId `480` (Spacewar)!*
     pub fn get_num_achievements(&self) -> Result<u32, ()> {
         unsafe {
-            let num = sys::SteamAPI_ISteamUserStats_GetNumAchievements(self.user_stats);
+            let num = self
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetNumAchievements(self.user_stats);
             if num != 0 {
                 Ok(num)
             } else {
@@ -498,7 +526,10 @@ impl<Manager> UserStats<Manager> {
 
         for i in 0..num {
             unsafe {
-                let name = sys::SteamAPI_ISteamUserStats_GetAchievementName(self.user_stats, i);
+                let name = self
+                    .inner
+                    .lib
+                    .SteamAPI_ISteamUserStats_GetAchievementName(self.user_stats, i);
 
                 let c_str = CStr::from_ptr(name).to_string_lossy().into_owned();
 

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -33,11 +33,15 @@ impl<M> AchievementHelper<'_, M> {
     pub fn get(&self) -> Result<bool, ()> {
         unsafe {
             let mut achieved = false;
-            let success = sys::SteamAPI_ISteamUserStats_GetAchievement(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                &mut achieved as *mut _,
-            );
+            let success = self
+                .parent
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetAchievement(
+                    self.parent.user_stats,
+                    self.name.as_ptr() as *const _,
+                    &mut achieved as *mut _,
+                );
             if success {
                 Ok(achieved)
             } else {
@@ -56,10 +60,13 @@ impl<M> AchievementHelper<'_, M> {
     /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
     pub fn set(&self) -> Result<(), ()> {
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetAchievement(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-            )
+            self.parent
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_SetAchievement(
+                    self.parent.user_stats,
+                    self.name.as_ptr() as *const _,
+                )
         };
         if success {
             Ok(())
@@ -78,10 +85,13 @@ impl<M> AchievementHelper<'_, M> {
     /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
     pub fn clear(&self) -> Result<(), ()> {
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_ClearAchievement(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-            )
+            self.parent
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_ClearAchievement(
+                    self.parent.user_stats,
+                    self.name.as_ptr() as *const _,
+                )
         };
         if success {
             Ok(())
@@ -120,11 +130,15 @@ impl<M> AchievementHelper<'_, M> {
     pub fn get_achievement_achieved_percent(&self) -> Result<f32, ()> {
         unsafe {
             let mut percent = 0.0;
-            let success = sys::SteamAPI_ISteamUserStats_GetAchievementAchievedPercent(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                &mut percent as *mut _,
-            );
+            let success = self
+                .parent
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetAchievementAchievedPercent(
+                    self.parent.user_stats,
+                    self.name.as_ptr() as *const _,
+                    &mut percent as *mut _,
+                );
             if success {
                 Ok(percent)
             } else {
@@ -170,11 +184,15 @@ impl<M> AchievementHelper<'_, M> {
             let key_c_str = CString::new(key).expect("Failed to create c_str from key parameter");
             let ptr = key_c_str.as_ptr() as *const i8;
 
-            let str = sys::SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                ptr,
-            );
+            let str = self
+                .parent
+                .inner
+                .lib
+                .SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(
+                    self.parent.user_stats,
+                    self.name.as_ptr() as *const _,
+                    ptr,
+                );
 
             let c_str = CStr::from_ptr(str);
 
@@ -200,8 +218,9 @@ impl<M> AchievementHelper<'_, M> {
 
     fn internal_get_achievement_icon(&self, avoid_big_icons: bool) -> Option<(Vec<u8>, u32, u32)> {
         unsafe {
-            let utils: *mut sys::ISteamUtils = sys::SteamAPI_SteamUtils_v010();
-            let img = sys::SteamAPI_ISteamUserStats_GetAchievementIcon(
+            let lib = &self.parent.inner.lib;
+            let utils: *mut sys::ISteamUtils = lib.SteamAPI_SteamUtils_v010();
+            let img = lib.SteamAPI_ISteamUserStats_GetAchievementIcon(
                 self.parent.user_stats,
                 self.name.as_ptr() as *const _,
             );
@@ -210,14 +229,14 @@ impl<M> AchievementHelper<'_, M> {
             }
             let mut width = 0;
             let mut height = 0;
-            if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
+            if !lib.SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
                 return None;
             }
             if avoid_big_icons && (width != 64 || height != 64) {
                 return None;
             }
             let mut dest = vec![0; (width * height * 4).try_into().unwrap()];
-            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(
+            if !lib.SteamAPI_ISteamUtils_GetImageRGBA(
                 utils,
                 img,
                 dest.as_mut_ptr(),

--- a/steamworks-sys/src/lib.rs
+++ b/steamworks-sys/src/lib.rs
@@ -10,3 +10,81 @@ include!("macos_bindings.rs");
 
 #[cfg(target_os = "linux")]
 include!("linux_bindings.rs");
+
+// User stats callback structures
+// These are used for receiving callback data from Steam
+
+/// Callback for RequestCurrentStats
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct UserStatsReceived_t {
+    pub m_nGameID: u64,
+    pub m_eResult: EResult,
+    pub m_steamIDUser: CSteamID,
+}
+
+/// Callback for StoreStats
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct UserStatsStored_t {
+    pub m_nGameID: u64,
+    pub m_eResult: EResult,
+}
+
+/// Callback for achievement storage
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct UserAchievementStored_t {
+    pub m_nGameID: u64,
+    pub m_bGroupAchievement: bool,
+    pub m_rgchAchievementName: [::std::os::raw::c_char; 128],
+    pub m_nCurProgress: u32,
+    pub m_nMaxProgress: u32,
+}
+
+/// Callback for achievement icon fetch
+#[repr(C, packed(4))]
+#[derive(Copy, Clone)]
+pub struct UserAchievementIconFetched_t {
+    pub m_nGameID: CGameID,
+    pub m_rgchAchievementName: [::std::os::raw::c_char; 128],
+    pub m_bAchieved: bool,
+    pub m_nIconHandle: ::std::os::raw::c_int,
+}
+
+/// Callback for FindLeaderboard
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct LeaderboardFindResult_t {
+    pub m_hSteamLeaderboard: u64,
+    pub m_bLeaderboardFound: u8,
+}
+
+/// Callback for UploadLeaderboardScore
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct LeaderboardScoreUploaded_t {
+    pub m_bSuccess: u8,
+    pub m_hSteamLeaderboard: u64,
+    pub m_nScore: i32,
+    pub m_bScoreChanged: u8,
+    pub m_nGlobalRankNew: ::std::os::raw::c_int,
+    pub m_nGlobalRankPrevious: ::std::os::raw::c_int,
+}
+
+/// Callback for DownloadLeaderboardEntries
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct LeaderboardScoresDownloaded_t {
+    pub m_hSteamLeaderboard: u64,
+    pub m_hSteamLeaderboardEntries: u64,
+    pub m_cEntryCount: ::std::os::raw::c_int,
+}
+
+/// Callback for RequestGlobalAchievementPercentages
+#[repr(C, packed(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct GlobalAchievementPercentagesReady_t {
+    pub m_nGameID: u64,
+    pub m_eResult: EResult,
+}


### PR DESCRIPTION
## Summary

- Enables the `user_stats` module which was previously commented out
- Adapts the module to use the dynamic library loading pattern established in this fork
- Adds missing callback struct definitions required for Steam API responses

## Changes

### src/lib.rs
- Uncommented `mod user_stats` and `pub use crate::user_stats::*`
- Added `CString` import for string handling
- Added `user_stats()` method to `Client` implementation

### src/user_stats.rs & src/user_stats/stats.rs
- Updated all Steam API calls to use dynamic library pattern (`self.inner.lib.SteamAPI_*` instead of `sys::SteamAPI_*`)
- For closures that need library access, cloned the `lib` Arc before capturing

### steamworks-sys/src/lib.rs
- Added 8 callback struct definitions missing from auto-generated bindings:
  - `UserStatsReceived_t` - callback for RequestCurrentStats
  - `UserStatsStored_t` - callback for StoreStats
  - `UserAchievementStored_t` - callback for achievement storage
  - `UserAchievementIconFetched_t` - callback for achievement icon fetch
  - `LeaderboardFindResult_t` - callback for FindLeaderboard
  - `LeaderboardScoreUploaded_t` - callback for UploadLeaderboardScore
  - `LeaderboardScoresDownloaded_t` - callback for DownloadLeaderboardEntries
  - `GlobalAchievementPercentagesReady_t` - callback for RequestGlobalAchievementPercentages

## Features Enabled

- **Achievements**: get/set/clear, display attributes, icons, global unlock percentages
- **Leaderboards**: find, create, upload scores, download entries, get metadata (name, entry count, sort method, display type)
- **Stats**: get/set i32 and f32 stats, store stats, reset all stats

## Test plan

- [x] `cargo check` passes successfully
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)